### PR TITLE
Allow to mock time.Now() in tests

### DIFF
--- a/time.go
+++ b/time.go
@@ -3,4 +3,4 @@ package jose
 import "time"
 
 // Now returns the current time in UTC.
-func Now() time.Time { return time.Now().UTC() }
+var Now = func() time.Time { return time.Now().UTC() }


### PR DESCRIPTION
This would help testing JWTs reproducibly (e.g. with shorter expiry times)